### PR TITLE
🧹 rename go package to packer-plugin-cnspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ main
 dist/*
 docs-rendered/*
 packer-plugin-mondoo
+packer-plugin-cnspec
 .docs

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X go.mondoo.com/packer-plugin-mondoo/version.Version={{.Version}} -X go.mondoo.com/packer-plugin-mondoo/version.Build={{.ShortCommit}} -X go.mondoo.com/packer-plugin-mondoo/version.Date={{.Date}}
+      - -s -w -X go.mondoo.com/packer-plugin-cnspec/version.Version={{.Version}} -X go.mondoo.com/packer-plugin-cnspec/version.Build={{.ShortCommit}} -X go.mondoo.com/packer-plugin-cnspec/version.Date={{.Date}}
   # building fall-back binaries
   - id: packer-plugin-mondoo
     binary: 'packer-plugin-mondoo_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
@@ -31,7 +31,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X go.mondoo.com/packer-plugin-mondoo/version.Version={{.Version}} -X go.mondoo.com/packer-plugin-mondoo/version.Build={{.ShortCommit}} -X go.mondoo.com/packer-plugin-mondoo/version.Date={{.Date}}
+      - -s -w -X go.mondoo.com/packer-plugin-cnspec/version.Version={{.Version}} -X go.mondoo.com/packer-plugin-cnspec/version.Build={{.ShortCommit}} -X go.mondoo.com/packer-plugin-cnspec/version.Date={{.Date}}
 
 archives:
   - id: releases-packer-plugin-cnspec

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NAME=mondoo
+NAME=cnspec
 BINARY=packer-plugin-${NAME}
 
 COUNT?=1
@@ -8,7 +8,7 @@ HASHICORP_PACKER_PLUGIN_SDK_VERSION?=$(shell go list -m github.com/hashicorp/pac
 .PHONY: dev
 
 build:
-	CGO_ENABLED=0 go build -o ${BINARY} -ldflags="-X go.mondoo.com/packer-plugin-mondoo/version.Version=0.0.0 -X go.mondoo.com/packer-plugin-mondoo/version.Build=dev"
+	CGO_ENABLED=0 go build -o ${BINARY} -ldflags="-X go.mondoo.com/packer-plugin-cnspec/version.Version=0.0.0 -X go.mondoo.com/packer-plugin-cnspec/version.Build=dev"
 
 dev: build
 	@mkdir -p ~/.packer.d/plugins/

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Once you have downloaded the latest archive corresponding to your target OS, unc
 
 ### Build from source
 
-If you prefer to build the plugin from sources, clone the GitHub repository locally and run the command `go build` from the root directory. Upon successful compilation, a `packer-plugin-cnspec` plugin binary file can be found in the root directory. To install the compiled plugin, please follow the official Packer documentation on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+If you prefer to build the plugin from source, clone the GitHub repository locally and run the command `go build` from the root directory. Upon successful compilation, a `packer-plugin-cnspec` plugin binary file can be found in the root directory. To install the compiled plugin, please follow the official Packer documentation on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
 
 By using `make dev`, the binary is copied into `~/.packer.d/plugins/` after the build.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Once you have downloaded the latest archive corresponding to your target OS, unc
 
 ### Build from source
 
-If you prefer to build the plugin from sources, clone the GitHub repository locally and run the command `go build` from the root directory. Upon successful compilation, a `packer-plugin-mondoo` plugin binary file can be found in the root directory. To install the compiled plugin, please follow the official Packer documentation on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+If you prefer to build the plugin from sources, clone the GitHub repository locally and run the command `go build` from the root directory. Upon successful compilation, a `packer-plugin-cnspec` plugin binary file can be found in the root directory. To install the compiled plugin, please follow the official Packer documentation on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
 
 By using `make dev`, the binary is copied into `~/.packer.d/plugins/` after the build.
 

--- a/docs/provisioners/mondoo.mdx
+++ b/docs/provisioners/mondoo.mdx
@@ -54,4 +54,4 @@ If you are new to Mondoo you can get started by [signing up for a free account](
 Check out the [Building secure AMIs with Mondoo and Packer](https://mondoo.com/docs/tutorials/aws/build-secure-amis-packer/), or [Building secure VM images in Google Cloud with Mondoo and Packer](https://mondoo.com/docs/tutorials/gcp/build-secure-gcp-vm-images-packer/) tutorial on the Mondoo documentation site.
 ## Sample Packer Templates
 
-You can find example Packer templates in the [examples](https://github.com/mondoohq/packer-plugin-mondoo/tree/main/examples) directory in this repository.
+You can find example Packer templates in the [examples](https://github.com/mondoohq/packer-plugin-cnspec/tree/main/examples) directory in this repository.

--- a/download.sh
+++ b/download.sh
@@ -32,14 +32,14 @@ case "$(uname -m)" in
 esac
 
 # automatic download of latest version
-version=$(curl https://api.github.com/repos/mondoohq/packer-plugin-mondoo/releases/latest | jq -r .name)
+version=$(curl https://api.github.com/repos/mondoohq/packer-plugin-cnspec/releases/latest | jq -r .name)
 # alternative set the version manually
 # version=v0.4.0
 
-archive="packer-plugin-mondoo_${version}_x5.0_${os}_${arch}.zip"
-sha="packer-plugin-mondoo_${version}_SHA256SUMS"
+archive="packer-plugin-cnspec_${version}_x5.0_${os}_${arch}.zip"
+sha="packer-plugin-cnspec_${version}_SHA256SUMS"
 echo Download "${archive}" from
-url="https://github.com/mondoohq/packer-plugin-mondoo/releases/download/${version}"
+url="https://github.com/mondoohq/packer-plugin-cnspec/releases/download/${version}"
 echo "${url}"
 
 curl -sSL "${url}/${archive}" > "${archive}"
@@ -59,7 +59,7 @@ unzip "${archive}"
 rm "${archive}" "${sha}"
 
 mkdir -p ~/.packer.d/plugins
-mv "packer-plugin-mondoo_${version}_x5.0_${os}_${arch}" ~/.packer.d/plugins/packer-plugin-mondoo
+mv "packer-plugin-cnspec_${version}_x5.0_${os}_${arch}" ~/.packer.d/plugins/packer-plugin-cnspec
 echo "Marking executable..."
-chmod +x ~/.packer.d/plugins/packer-plugin-mondoo
+chmod +x ~/.packer.d/plugins/packer-plugin-cnspec
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.mondoo.com/packer-plugin-mondoo
+module go.mondoo.com/packer-plugin-cnspec
 
 require (
 	github.com/cockroachdb/errors v1.9.0

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 
 	"github.com/hashicorp/packer-plugin-sdk/plugin"
-	"go.mondoo.com/packer-plugin-mondoo/provisioner"
-	"go.mondoo.com/packer-plugin-mondoo/version"
+	"go.mondoo.com/packer-plugin-cnspec/provisioner"
+	"go.mondoo.com/packer-plugin-cnspec/version"
 )
 
 func main() {

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -36,7 +36,7 @@ import (
 	"go.mondoo.com/cnspec/cli/reporter"
 	"go.mondoo.com/cnspec/policy"
 	"go.mondoo.com/cnspec/policy/scan"
-	"go.mondoo.com/packer-plugin-mondoo/version"
+	"go.mondoo.com/packer-plugin-cnspec/version"
 	"go.mondoo.com/ranger-rpc"
 	"golang.org/x/crypto/ssh"
 )


### PR DESCRIPTION
This PR changes the go module name to `packer-plugin-cnspec`