### PR TITLE
🧹 only build go app if the files have been changed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,12 @@
 name: goreleaser
 
+## Only trigger tests if source is changing
 on:
-  pull_request:
+  push:
+    paths:
+      - '**.go'
+      - '**.mod'
+      - 'go.sum'
 
 jobs:
   goreleaser:


### PR DESCRIPTION
reduces the github action time when no code was changed