### PR TITLE
🧹 always print debug log when debugging is enabled

### DIFF
--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -439,6 +439,11 @@ func (p *Provisioner) executeCnspec(ui packer.Ui, comm packer.Communicator) erro
 
 		// configure stderr logger
 		logger.Set("debug")
+
+		// log output for debug/error logs
+		defer func() {
+			ui.Message(debugLogBuffer.String())
+		}()
 	}
 
 	// base 64 config env setting has always precedence
@@ -546,8 +551,6 @@ func (p *Provisioner) executeCnspec(ui packer.Ui, comm packer.Communicator) erro
 		result, err = scanService.Run(context.Background(), scanJob)
 		if err != nil {
 			ui.Error("scan failed: " + err.Error())
-			// log output for debug/error logs
-			ui.Error(debugLogBuffer.String())
 			return err
 		}
 	}


### PR DESCRIPTION
prints debug logging even when no error happened during scan

<img width="1407" alt="Screenshot 2022-12-11 at 23 59 11" src="https://user-images.githubusercontent.com/1178413/206933925-c94b0928-0254-47d5-8d00-42a5d425db1b.png">
