### PR TITLE
Update mondoo.mdx - Fix cnspec provisioner link

### DIFF
--- a/docs/provisioners/mondoo.mdx
+++ b/docs/provisioners/mondoo.mdx
@@ -10,7 +10,7 @@ sidebar_title: Mondoo
 
 Type: `mondoo`
 
->This plugin has been deprecated. Migrate to [Packer plugin cnspec by Mondoo](https://developer.hashicorp.com/packer/plugins/provisioners/cnspec) for even easier security scanning of your Packer builds.
+>This plugin has been deprecated. Migrate to [Packer plugin cnspec by Mondoo](https://developer.hashicorp.com/packer/plugins/provisioners/mondoo/cnspec) for even easier security scanning of your Packer builds.
 
 The `mondoo` provisioner scans [Packer](https://www.packer.io) builds for vulnerabilities and misconfigurations by executing security
 policies-as-code enabled in [Mondoo Platform](https://console.mondoo.com). Mondoo Platform comes stocked with an ever-increasing collection of


### PR DESCRIPTION
It looks like the URL to the cnspec provisioner is no longer accurate, as HashiCorp made some changes on their side.  This fixes that!