### PR TITLE
🧹 Set cnquery version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,14 @@ ifndef VERSION
 VERSION=${LATEST_VERSION_TAG}+$(shell git rev-list --count HEAD)
 endif
 
+ifndef CNSPEC_VERSION
+CNSPEC_VERSION=$(shell go list -json -m go.mondoo.com/cnspec/v9 | jq -r ".Version")
+endif
+
 .PHONY: dev
 
 build:
-	CGO_ENABLED=0 go build -o ${BINARY} -ldflags="-X go.mondoo.com/packer-plugin-cnspec/version.Version=${VERSION} -X go.mondoo.com/packer-plugin-cnspec/version.Build=${TAG}"
+	CGO_ENABLED=0 go build -o ${BINARY} -ldflags="-X go.mondoo.com/cnquery/v9.Version=${CNSPEC_VERSION} -X go.mondoo.com/packer-plugin-cnspec/version.Version=${VERSION} -X go.mondoo.com/packer-plugin-cnspec/version.Build=${TAG}"
 
 dev: build
 	@mkdir -p ~/.packer.d/plugins/


### PR DESCRIPTION
This sets the version to the imported module version. This version is displayed with mondoo.version.

Fixes #139