### PR TITLE
🧹 Set cnquery version for goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,8 @@ jobs:
         with:
           go-version: ">=${{ env.golang-version }}"
           cache: false
+      - name: Set cnspec version
+        run: echo "CNSPEC_VERSION=$(go list -json -m go.mondoo.com/cnspec/v9 | jq -r '.Version')" >> $GITHUB_ENV
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -32,6 +34,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           API_VERSION: x5.0
+          CNSPEC_VERSION: ${{ env.CNSPEC_VERSION }}
       - name: Install Github CLI (gh)
         if: ${{ env.RUNNER_TYPE != 'self-hosted' }}
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,7 +22,7 @@ builds:
       - arm64
       - arm
     ldflags:
-      - -s -w -X go.mondoo.com/packer-plugin-cnspec/version.Version={{.Version}} -X go.mondoo.com/packer-plugin-cnspec/version.Build={{.ShortCommit}} -X go.mondoo.com/packer-plugin-cnspec/version.Date={{.Date}}
+      - -s -w -X go.mondoo.com/cnquery/v9.Version={{ .Env.CNSPEC_VERSION }} -X go.mondoo.com/packer-plugin-cnspec/version.Version={{.Version}} -X go.mondoo.com/packer-plugin-cnspec/version.Build={{.ShortCommit}} -X go.mondoo.com/packer-plugin-cnspec/version.Date={{.Date}}
   - id: packer-plugin-cnspec-windows
     binary: 'packer-plugin-cnspec_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
     goos:
@@ -31,7 +31,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X go.mondoo.com/packer-plugin-cnspec/version.Version={{.Version}} -X go.mondoo.com/packer-plugin-cnspec/version.Build={{.ShortCommit}} -X go.mondoo.com/packer-plugin-cnspec/version.Date={{.Date}}
+      - -s -w -X go.mondoo.com/cnquery/v9.Version={{ .Env.CNSPEC_VERSION }} -X go.mondoo.com/packer-plugin-cnspec/version.Version={{.Version}} -X go.mondoo.com/packer-plugin-cnspec/version.Build={{.ShortCommit}} -X go.mondoo.com/packer-plugin-cnspec/version.Date={{.Date}}
   - id: packer-plugin-cnspec-darwin
     binary: 'packer-plugin-cnspec_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
     goos:
@@ -40,7 +40,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X go.mondoo.com/packer-plugin-cnspec/version.Version={{.Version}} -X go.mondoo.com/packer-plugin-cnspec/version.Build={{.ShortCommit}} -X go.mondoo.com/packer-plugin-cnspec/version.Date={{.Date}} 
+      - -s -w -X go.mondoo.com/cnquery/v9.Version={{ .Env.CNSPEC_VERSION }} -X go.mondoo.com/packer-plugin-cnspec/version.Version={{.Version}} -X go.mondoo.com/packer-plugin-cnspec/version.Build={{.ShortCommit}} -X go.mondoo.com/packer-plugin-cnspec/version.Date={{.Date}} 
   
   # building fall-back binaries
   - id: packer-plugin-mondoo


### PR DESCRIPTION
This sets the version to the imported module version. This version is displayed with mondoo.version.

Fixes #139 for goreleaser