### PR TITLE
🧹 do not apply copyright header for hcl terraform templates

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -13,5 +13,6 @@ project {
     "**/testdata/**",
     "**/*.pb.go",
     "**/*_string.go",
+    "**/*pkrtpl.hcl",
   ]
 }

--- a/examples/packer-vsphere/photon4/data/ks.pkrtpl.hcl
+++ b/examples/packer-vsphere/photon4/data/ks.pkrtpl.hcl
@@ -1,6 +1,3 @@
-# Copyright (c) Mondoo, Inc.
-# SPDX-License-Identifier: BUSL-1.1
-
 {
     "hostname": "photon",
     "password":

--- a/examples/packer-vsphere/photon4/photon.pkr.hcl
+++ b/examples/packer-vsphere/photon4/photon.pkr.hcl
@@ -233,6 +233,7 @@ build {
     sudo {
       active = true
     }
+
     annotations = {
       build_date = local.build_date
       os_family  = var.vm_guest_os_family


### PR DESCRIPTION
Adding copyright header into hcl templates renders the data wrong for the machines and it leads to errors.