### PR TITLE
🐛 explicitly set sudo executable when sudo is activated

### DIFF
--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -335,7 +335,8 @@ func (p *Provisioner) executeCnspec(ui packer.Ui, comm packer.Communicator) erro
 	if p.config.Sudo != nil && p.config.Sudo.Active {
 		ui.Message("activated sudo")
 		assetConfig.Sudo = &inventory.Sudo{
-			Active: p.config.Sudo.Active,
+			Active:     p.config.Sudo.Active,
+			Executable: "sudo",
 		}
 	}
 


### PR DESCRIPTION
This is also fixed upstream for future versions https://github.com/mondoohq/cnquery/pull/2858