### PR TITLE
⭐️ support writing reports to file

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ env:
 before:
   hooks:
     - go mod download
-    - make ci-release-docs
+    - make generate
     # Check plugin compatibility with required version of the Packer SDK
     - make plugin-check
 builds:

--- a/.web-docs/components/provisioner/cnspec/README.md
+++ b/.web-docs/components/provisioner/cnspec/README.md
@@ -78,8 +78,10 @@ Optional Parameters:
 - `use_proxy` (bool) - Use proxy to connect to host to scan. This configuration will fall-back to
   packer proxy for cases where the provisioner cannot access the target directly
 
-- `output` (string) - Set output format: summary, full, yaml, json, csv, compact, report, junit
+- `output` (string) - Set output format: compact, csv, full, json, junit, report, summary, yaml
   (default "compact")
+
+- `output_target` (string) - Set output target. E.g. path to local file
 
 - `score_threshold` (int) - An integer value to set the `score_threshold` of mondoo scans. Defaults to
   `0` which results in a passing score regardless of what scan results are

--- a/.web-docs/components/provisioner/mondoo/README.md
+++ b/.web-docs/components/provisioner/mondoo/README.md
@@ -92,8 +92,10 @@ Optional Parameters:
 - `use_proxy` (bool) - Use proxy to connect to host to scan. This configuration will fall-back to
   packer proxy for cases where the provisioner cannot access the target directly
 
-- `output` (string) - Set output format: summary, full, yaml, json, csv, compact, report, junit
+- `output` (string) - Set output format: compact, csv, full, json, junit, report, summary, yaml
   (default "compact")
+
+- `output_target` (string) - Set output target. E.g. path to local file
 
 - `score_threshold` (int) - An integer value to set the `score_threshold` of mondoo scans. Defaults to
   `0` which results in a passing score regardless of what scan results are

--- a/README.md
+++ b/README.md
@@ -82,17 +82,31 @@ packer build amazon-linux-2.pkr.hcl
 | `on_failure`         | Set `on_failure = "continue"` to ignore build failures that do not meet any set `score_threshold`.                                                                                                                                                                                                         | `string`         | None        | No           |
 | `score_threshold`    | Set a score threshold for Packer builds `[0-100]`. Any scans that fall below the `score_threshold` will fail unless `on_failure = "continue"`. To learn more, read [How Mondoo scores policies](https://mondoo.com/docs/platform/console/monitor/#how-mondoo-scores-policies) in the Mondoo documentation. | `int`            | None        | No           |
 | `sudo`               | Use sudo to elevate permissions when running Mondoo scans.                                                                                                                                                                                                                                                 | `bool`           | None        | No           |
-| `mondoo_config_path` | The path to the configuration to be used when running Mondoo scans.                                                                                                                                                                                                                                        | `string`         | None        | No           |
+| `mondoo_config_path` | The path to the Mondoo's service account. Defaults to `$HOME/.config/mondoo/mondoo.yml`                                                                                                                                                                                                                    | `string`         | None        | No           |
+| `output`             | Set output format: compact, csv, full, json, junit, report, summary, yaml (default "compact")                                                                                                                                                                                                              | `string`         | None        | No           |
+| `output_target`      | Set output target. E.g. path to local file `result.xml`                                                                                                                                                                                                                                                    | `string`         | None        | No           |
 
 ### Example: Complete Configuration
 
-```bash
+A simple configuration where we set a score threshold of 85 and use sudo to elevate permissions when running the scans:
+
+```hcl
 provisioner "cnspec" {
   on_failure      = "continue"
   score_threshold = 85
   sudo {
     active = true
   }
+}
+```
+
+The following configuration shows how to set the output format to JUnit and the output target to `test-results.xml`:
+
+```hcl
+provisioner "cnspec" {
+  on_failure = "continue"
+  output = "junit"
+  output_target = "test-results.xml"
 }
 ```
 

--- a/docs-partials/provisioner/Config-not-required.mdx
+++ b/docs-partials/provisioner/Config-not-required.mdx
@@ -60,8 +60,10 @@
 - `use_proxy` (bool) - Use proxy to connect to host to scan. This configuration will fall-back to
   packer proxy for cases where the provisioner cannot access the target directly
 
-- `output` (string) - Set output format: summary, full, yaml, json, csv, compact, report, junit
+- `output` (string) - Set output format: compact, csv, full, json, junit, report, summary, yaml
   (default "compact")
+
+- `output_target` (string) - Set output target. E.g. path to local file
 
 - `score_threshold` (int) - An integer value to set the `score_threshold` of mondoo scans. Defaults to
   `0` which results in a passing score regardless of what scan results are

--- a/examples/packer-docker/docker-ubuntu.pkr.hcl
+++ b/examples/packer-docker/docker-ubuntu.pkr.hcl
@@ -45,5 +45,7 @@ build {
     annotations = {
       Name          = "${var.image_prefix}-${local.timestamp}"
     }
+    output = "junit"
+    output_target = "test-results.xml"
   }
 }

--- a/provisioner/provisioner.hcl2spec.go
+++ b/provisioner/provisioner.hcl2spec.go
@@ -37,6 +37,7 @@ type FlatConfig struct {
 	WinRMPassword        *string           `mapstructure:"winrm_password" cty:"winrm_password" hcl:"winrm_password"`
 	UseProxy             *bool             `mapstructure:"use_proxy" cty:"use_proxy" hcl:"use_proxy"`
 	Output               *string           `mapstructure:"output" cty:"output" hcl:"output"`
+	OutputTarget         *string           `mapstructure:"output_target" cty:"output_target" hcl:"output_target"`
 	ScoreThreshold       *int              `mapstructure:"score_threshold" cty:"score_threshold" hcl:"score_threshold"`
 	MondooConfigPath     *string           `mapstructure:"mondoo_config_path" cty:"mondoo_config_path" hcl:"mondoo_config_path"`
 }
@@ -80,6 +81,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_password":             &hcldec.AttrSpec{Name: "winrm_password", Type: cty.String, Required: false},
 		"use_proxy":                  &hcldec.AttrSpec{Name: "use_proxy", Type: cty.Bool, Required: false},
 		"output":                     &hcldec.AttrSpec{Name: "output", Type: cty.String, Required: false},
+		"output_target":              &hcldec.AttrSpec{Name: "output_target", Type: cty.String, Required: false},
 		"score_threshold":            &hcldec.AttrSpec{Name: "score_threshold", Type: cty.Number, Required: false},
 		"mondoo_config_path":         &hcldec.AttrSpec{Name: "mondoo_config_path", Type: cty.String, Required: false},
 	}


### PR DESCRIPTION
after #175
fixes https://github.com/mondoohq/packer-plugin-cnspec/issues/98

The following configuration shows how to set the output format to JUnit and the output target to `test-results.xml`:

```hcl
provisioner "cnspec" {
  on_failure = "continue"
  output = "junit"
  output_target = "test-results.xml"
}
```