### PR TITLE
🧹 docs.zip is not needed anymore

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,13 +77,6 @@ checksum:
   algorithm: sha256
 snapshot:
   name_template: "{{ .Tag }}-snapshot"
-release:
-  # If you want to manually examine the release before its live, uncomment this line:
-  # draft: true
-  # As part of the release doc files are included as a separate deliverable for consumption by Packer.io.
-  # To include a separate docs.zip uncomment the extra_files config and the docs.zip command hook above.
-  extra_files:
-  - glob: ./docs.zip
 
 changelog:
   use: github-native


### PR DESCRIPTION
Followup https://github.com/mondoohq/packer-plugin-cnspec/pull/153/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L62-L65