### PR TITLE
⭐️ support ssh agent authentication

### DIFF
--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -372,6 +372,12 @@ func (p *Provisioner) executeCnspec(ui packer.Ui, comm packer.Communicator) erro
 		} else if len(p.buildInfo.SSHPrivateKey) > 0 {
 			cred := vault.NewPrivateKeyCredential(p.buildInfo.User, []byte(p.buildInfo.SSHPrivateKey), "")
 			assetConfig.Credentials = append(assetConfig.Credentials, cred)
+		} else if p.buildInfo.SSHAgentAuth {
+			cred := &vault.Credential{
+				Type: vault.CredentialType_ssh_agent,
+				User: p.buildInfo.User,
+			}
+			assetConfig.Credentials = append(assetConfig.Credentials, cred)
 		} else {
 			// fallback to password auth
 			cred := vault.NewPasswordCredential(p.buildInfo.User, p.buildInfo.Password)


### PR DESCRIPTION
This fixes #187

When users used an aws setup with ssh agent authentication the provider could not connect to the remote machine.

```
source "amazon-ebs" "ubuntu2204" {
  ami_name      = "${var.image_prefix}-${local.timestamp}"
  instance_type = "t2.micro"
  region        = var.aws_region
  source_ami_filter {
    filters = {
      name                = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
      root-device-type    = "ebs"
      virtualization-type = "hvm"
    }
    most_recent = true
    owners      = ["099720109477"]
  }
  ssh_username = "ubuntu"

  ssh_keypair_name = "chris-rock"
  ssh_agent_auth   = true
}
```