### PR TITLE
🧹 Fix version generation in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 
 ifndef VERSION
 # echo "read VERSION from git"
-VERSION=${LATEST_VERSION_TAG}+$(shell git rev-list --count HEAD)
+VERSION=${LATEST_VERSION_TAG}-$(shell git rev-list --count HEAD)
 endif
 
 ifndef CNSPEC_VERSION


### PR DESCRIPTION
Ensure we use a `-` instead of a `+`. If the tag has a `+` that would mean the version has two of those and packer does not like that