### PR TITLE
🧹 set hostname for rocky

### DIFF
--- a/examples/vsphere/rocky8/data/ks.pkrtpl.hcl
+++ b/examples/vsphere/rocky8/data/ks.pkrtpl.hcl
@@ -28,7 +28,7 @@ keyboard ${vm_guest_os_keyboard}
 ### --noipv6	  disable IPv6 on this device
 ###
 ### network  --bootproto=static --ip=172.16.11.200 --netmask=255.255.255.0 --gateway=172.16.11.200 --nameserver=172.16.11.4 --hostname centos-linux-8
-network --bootproto=dhcp
+network --hostname=${hostname} --bootproto=dhcp
 
 ### Lock the root account.
 rootpw --lock


### PR DESCRIPTION
We experienced some issues where two builds of the cnspec provisioner update same asset in Mondoo platform. This is caused by the fact that two builds have the same hostname. Therefore users should make sure that different builds get different hostnames. In our rocky example for vsphree we explicitly set the hostname for the build. 