### PR TITLE
🤖 Automatically create GH release after cnspec bump

### DIFF
--- a/.github/workflows/cnspec-update.yml
+++ b/.github/workflows/cnspec-update.yml
@@ -55,6 +55,7 @@ jobs:
           MAJOR=$(echo "${{ steps.version.outputs.version }}" | cut -d. -f1)
           go get go.mondoo.com/cnspec/${MAJOR}@${{ steps.version.outputs.version }}
           go mod tidy
+          echo "${{ steps.version.outputs.version }}" > VERSION
 
       - name: Prepare title and branch name
         id: branch

--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -1,0 +1,26 @@
+name: Create GitHub Release
+
+## Only trigger release when the VERSION file changed
+on:
+  push:
+    paths:
+      - "VERSION"
+
+jobs:
+  create-gh-release:
+    name: GH Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set release version
+        run: echo "RELEASE_VERSION=$(cat VERSION)" >> $GITHUB_ENV
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_VERSION }}
+          generate_release_notes: true
+          make_latest: true
+          # for testing purposes
+          draft: true
+        


### PR DESCRIPTION
The idea is:
- When we merge a cnspec version bump PR, it updates the VERSION file in merge
- The new workflow triggers and creates the GH release (currently we do this manually)
- This will trigger the actual release builds and publishes

For now, this creates releases as drafts. When the releases are ok, we can remove the draft flag.