### PR TITLE
🤖 Un-draft GH releases

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -21,6 +21,3 @@ jobs:
           tag_name: ${{ env.RELEASE_VERSION }}
           generate_release_notes: true
           make_latest: true
-          # for testing purposes
-          draft: true
-        


### PR DESCRIPTION
It worked in yesterdays release:
https://github.com/mondoohq/packer-plugin-cnspec/pull/257

I only needed to confirm the release. Let's automate this and we can use the pattern also in other repos.