### PR TITLE
🐛 Fix the field that is checked for 'mondoo-tools'

### DIFF
--- a/.github/workflows/pr-test-lint.yaml
+++ b/.github/workflows/pr-test-lint.yaml
@@ -82,7 +82,7 @@ jobs:
     # For now, we only auto approve and merge cnspec bump PRs created by mondoo-tools.
     # We have to check the commit author, because the PR is created by "github-actions[bot]"
     # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#startswith
-    if: ${{ startsWith(github.ref, 'refs/heads/version/cnspec_update_v') && github.event.commits[0].author.name == 'mondoo-tools' }}
+    if: ${{ startsWith(github.ref, 'refs/heads/version/cnspec_update_v') && github.event.commits[0].author.username == 'mondoo-tools' }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Tha approval was skipped: https://github.com/mondoohq/packer-plugin-cnspec/actions/runs/11793691547/job/32849991279

Part of the event:
```
"event": {
    "after": "5d3ee94a90fec6e939a036d9f84cd7545ae345c1",
    "base_ref": null,
    "before": "0000000000000000000000000000000000000000",
    "commits": [
      {
        "author": {
          "email": "tools@mondoo.com",
          "name": "Mondoo Tools",
          "username": "mondoo-tools"
        },
        "committer": {
          "email": "tools@mondoo.com",
          "name": "Mondoo Tools",
          "username": "mondoo-tools"
        },
        "distinct": true,
        "id": "5d3ee94a90fec6e939a036d9f84cd7545ae345c1",
        "message": "🧹 Bump cnspec to v11.30.0",
        "timestamp": "2024-11-12T08:45:45Z",
        "tree_id": "168e5c55bb8d1d6d24143c77c5e20cb2fdb8d145",
        "url": "https://github.com/mondoohq/packer-plugin-cnspec/commit/5d3ee94a90fec6e939a036d9f84cd7545ae345c1"
      }
    ],
...
```
I checked the wrong field.