### PR TITLE
🧹 Switch to app token for release

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -41,13 +41,20 @@ jobs:
         uses: actions/checkout@v4
       - name: Set release version
         run: echo "RELEASE_VERSION=$(cat VERSION)" >> $GITHUB_ENV
+      # fetch a token for the mondoo-mergebot app
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
+          private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
           generate_release_notes: true
           make_latest: true
-          token: ${{ secrets.GH_BUILDER_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
       - name: Release file present?
         id: check_release_file
         uses: nick-fields/retry@v3


### PR DESCRIPTION
Same as we have in cnspec:
https://github.com/mondoohq/cnspec/blob/main/.github/workflows/gh-release.yaml#L45-L57

Does this repo have access to the app?