### PR TITLE
Simplify `ensure-generated` workflow

### DIFF
--- a/.github/workflows/ensure-generated.yaml
+++ b/.github/workflows/ensure-generated.yaml
@@ -16,10 +16,8 @@ jobs:
         with:
           go-version: ">=${{ env.golang-version }}"
           cache: false
-      - shell: bash
-        run: make generate
-      - shell: bash
-        run: |
+      - run: |
+          make generate
           if [[ -z "$(git status -s)" ]]; then
             echo "OK"
           else


### PR DESCRIPTION
1. There is no need to specify `shell: bash`, for `ubuntu-*`, it is the default
2. There is no need for two unnamed steps, so they've been merged into one