### PR TITLE
🧹 Fix deprecated/removed/moved parameters for golangci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,8 +4,9 @@
 # See https://golangci-lint.run/usage/configuration/ for configuration options
 run:
   timeout: 5m
-  skip-dirs:
-  skip-files:
+  modules-download-mode: readonly
+
+issues:
+  exclude-files:
     - ".*\\.pb\\.go$"
     - ".*\\.lr\\.go$"
-  modules-download-mode: readonly


### PR DESCRIPTION
This fixes https://github.com/mondoohq/packer-plugin-cnspec/actions/runs/13921192786/job/38954630816\?pr\=381

Same as https://github.com/mondoohq/cnspec/pull/1604