### PR TITLE
🧹 Bump go to v1.25

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,1 +1,1 @@
-golang-version=1.24.5
+golang-version=1.25.1

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module go.mondoo.com/packer-plugin-cnspec
 
-go 1.24.0
+go 1.25
 
-toolchain go1.24.3
+toolchain go1.25.1
 
 replace github.com/zclconf/go-cty => github.com/nywilken/go-cty v1.13.3 // added by packer-sdc fix as noted in github.com/hashicorp/packer-plugin-sdk/issues/187
 


### PR DESCRIPTION
Required for https://github.com/mondoohq/packer-plugin-cnspec/actions/runs/18309104157/job/52133291484