### PR TITLE
Pin self-hosted jobs to group instead of label

### DIFF
--- a/.github/workflows/pr-test-lint.yaml
+++ b/.github/workflows/pr-test-lint.yaml
@@ -24,7 +24,8 @@ jobs:
 
   goreleaser:
     name: GoReleaser
-    runs-on: self-hosted
+    runs-on:
+      group: Default
     env:
       RUNNER_TYPE: "self-hosted"
     timeout-minutes: 120

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   goreleaser:
-    runs-on: self-hosted
+    runs-on:
+      group: Default
     env:
       RUNNER_TYPE: "self-hosted"
     timeout-minutes: 120


### PR DESCRIPTION
use 
```    
runs-on:
  group: Default
```
instead of the default label for all self-hosted runners:
``` 
runs-on: self-hosted
```