### PR TITLE
ci: add check-latest to setup-go actions

### DIFF
--- a/.github/workflows/cnspec-update.yml
+++ b/.github/workflows/cnspec-update.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
       - name: Bump cnspec
         run: |

--- a/.github/workflows/ensure-generated.yaml
+++ b/.github/workflows/ensure-generated.yaml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
       - run: |
           make generate

--- a/.github/workflows/notify-integration-release-via-manual.yaml
+++ b/.github/workflows/notify-integration-release-via-manual.yaml
@@ -23,9 +23,10 @@ jobs:
       # Ensure that Docs are Compiled
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5.2.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
       - shell: bash
         run: make generate

--- a/.github/workflows/notify-integration-release-via-manual.yaml
+++ b/.github/workflows/notify-integration-release-via-manual.yaml
@@ -23,7 +23,7 @@ jobs:
       # Ensure that Docs are Compiled
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5.2.0
         with:
           go-version: ">=${{ env.golang-version }}"
           check-latest: true

--- a/.github/workflows/notify-integration-release-via-tag.yaml
+++ b/.github/workflows/notify-integration-release-via-tag.yaml
@@ -27,7 +27,7 @@ jobs:
       # Ensure that Docs are Compiled
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5.2.0
         with:
           go-version: ">=${{ env.golang-version }}"
           check-latest: true

--- a/.github/workflows/notify-integration-release-via-tag.yaml
+++ b/.github/workflows/notify-integration-release-via-tag.yaml
@@ -27,9 +27,10 @@ jobs:
       # Ensure that Docs are Compiled
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5.2.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
       - shell: bash
         run: make generate

--- a/.github/workflows/pr-test-lint.yaml
+++ b/.github/workflows/pr-test-lint.yaml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
       - name: Check go mod
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
       - name: Set cnspec version
         run: echo "CNSPEC_VERSION=$(go list -json -m go.mondoo.com/cnspec/v13 | jq -r '.Version')" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- Add `check-latest: true` to all 6 `actions/setup-go` usages so the action queries the Go download server for the latest matching version instead of only checking locally cached versions
- Fix stale version comments (`v5.2.0` → `v6.4.0`) in `notify-integration-release-via-manual.yaml` and `notify-integration-release-via-tag.yaml`

## Test plan
- [ ] Verify CI workflows run successfully with the updated configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)