### PR TITLE
ci: retry go get to handle sum.golang.org propagation delay

### DIFF
--- a/.github/workflows/cnspec-update.yml
+++ b/.github/workflows/cnspec-update.yml
@@ -64,17 +64,17 @@ jobs:
           # Retry `go get` to tolerate sum.golang.org / proxy.golang.org
           # propagation delay for freshly published tags (seen as 404 on
           # sum.golang.org/lookup/...).
-          attempt=1
+          attempts_made=0
           max_attempts=6
           until go get "${MODULE}"; do
-            if [ $attempt -ge $max_attempts ]; then
+            attempts_made=$((attempts_made + 1))
+            if [ $attempts_made -ge $max_attempts ]; then
               echo "go get failed after ${max_attempts} attempts"
               exit 1
             fi
-            sleep_seconds=$((attempt * 30))
-            echo "go get attempt ${attempt} failed; retrying in ${sleep_seconds}s..."
+            sleep_seconds=$((attempts_made * 30))
+            echo "go get attempt ${attempts_made}/${max_attempts} failed; retrying in ${sleep_seconds}s..."
             sleep $sleep_seconds
-            attempt=$((attempt + 1))
           done
           go mod tidy
           echo "$VERSION" > VERSION

--- a/.github/workflows/cnspec-update.yml
+++ b/.github/workflows/cnspec-update.yml
@@ -56,11 +56,28 @@ jobs:
           check-latest: true
           cache: false
       - name: Bump cnspec
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          MAJOR=$(echo "${{ steps.version.outputs.version }}" | cut -d. -f1)
-          go get go.mondoo.com/cnspec/${MAJOR}@${{ steps.version.outputs.version }}
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MODULE="go.mondoo.com/cnspec/${MAJOR}@${VERSION}"
+          # Retry `go get` to tolerate sum.golang.org / proxy.golang.org
+          # propagation delay for freshly published tags (seen as 404 on
+          # sum.golang.org/lookup/...).
+          attempt=1
+          max_attempts=6
+          until go get "${MODULE}"; do
+            if [ $attempt -ge $max_attempts ]; then
+              echo "go get failed after ${max_attempts} attempts"
+              exit 1
+            fi
+            sleep_seconds=$((attempt * 30))
+            echo "go get attempt ${attempt} failed; retrying in ${sleep_seconds}s..."
+            sleep $sleep_seconds
+            attempt=$((attempt + 1))
+          done
           go mod tidy
-          echo "${{ steps.version.outputs.version }}" > VERSION
+          echo "$VERSION" > VERSION
 
       - name: Prepare title and branch name
         id: branch


### PR DESCRIPTION
## Summary
- Wrap `go get` in the `Bump cnspec` workflow with a retry loop (6 attempts, 30s linear backoff) so that the workflow tolerates the propagation delay of `sum.golang.org` indexing freshly published cnspec tags.
- Also moves the version interpolation into an `env:` var to avoid repeated shell expansion of `\${{ }}`.

## Context
Run [25044179530](https://github.com/mondoohq/packer-plugin-cnspec/actions/runs/25044179530/attempts/1) failed on the first attempt with:

```
go: go.mondoo.com/cnspec/v13@v13.7.0: verifying module: go.mondoo.com/cnspec/v13@v13.7.0:
  reading https://sum.golang.org/lookup/go.mondoo.com/cnspec/v13@v13.7.0: 404 Not Found
```

The retry succeeded once the checksum DB had indexed the tag. The retry loop avoids requiring a manual re-run for this transient case.

## Test plan
- [ ] Trigger \`workflow_dispatch\` with a known-good cnspec version and confirm the workflow still passes.
- [ ] (Optional) Trigger with a freshly tagged cnspec version where the sum DB may still be propagating, and confirm the retry succeeds without manual re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)