### PR TITLE
ci: migrate workflow runners to arc-runners

### DIFF
--- a/.github/workflows/pr-test-lint.yaml
+++ b/.github/workflows/pr-test-lint.yaml
@@ -25,7 +25,7 @@ jobs:
   goreleaser:
     name: GoReleaser
     runs-on:
-      group: Default
+      group: arc-runners
     env:
       RUNNER_TYPE: "self-hosted"
     timeout-minutes: 120

--- a/.github/workflows/pr-test-lint.yaml
+++ b/.github/workflows/pr-test-lint.yaml
@@ -2,6 +2,7 @@ name: Build Packer Plugin
 
 ## Only trigger tests if source is changing
 on:
+  workflow_dispatch: # manual trigger to test-build on the runners without shipping (goreleaser stays --snapshot --skip=publish)
   push:
     paths:
       - "**.go"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   goreleaser:
     runs-on:
-      group: Default
+      group: arc-runners
     env:
       RUNNER_TYPE: "self-hosted"
     timeout-minutes: 120


### PR DESCRIPTION
Migrates `packer-plugin-cnspec` CI off the legacy **Default** runner group onto **ARC (`arc-runners`)**, part of the ongoing runner-pool migration.

## Runner swap (`group: Default` → `group: arc-runners`)
- `.github/workflows/pr-test-lint.yaml`
- `.github/workflows/release.yaml`

No private-module auth shim needed — this repo's `go.mod` pulls only **public** mondoohq modules (`cnspec`, `mql`, `ranger-rpc`, `mondoo-go`). Uses standard `actions/setup-go`, so none of the PATH / tool-gap issues seen elsewhere apply.

Draft so the first ARC run can be eyeballed before review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)